### PR TITLE
Add headerStyle inline style

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,14 +1,21 @@
 import "../styles/Header.css";
 
 const styles = {
-  
+  headerStyle: {
+    backgroundImage:
+      "linear-gradient(to top, #212529, #26292d, #2a2d31, #2f3236, #34363a, #434549, #525558, #626568, #838688, #a6a8aa, #cacccd, #f0f1f1)",
+    display: "flex",
+    justifyContent: "center",
+    fontFamily: "monospace",
+  },
+
   headingStyle: {
     fontSize: "100px",
     color: "silver",
     textAlign: "center",
     padding: "20px",
-    margin: "0", 
-    textShadow: "1px 1px 2px black"
+    margin: "0",
+    textShadow: "1px 1px 2px black",
   },
 };
 


### PR DESCRIPTION
## Summary
- define `headerStyle` in `Header` component with background and flex settings

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684cad5d992483229f6ba0ad60679182